### PR TITLE
Fix a couple small compiler errors

### DIFF
--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -86,8 +86,6 @@ and instead put a div inside and style that.
        * If true, the orientation is horizontal; otherwise is vertical.
        *
        * @attribute horizontal
-       * @type Boolean
-       * @default false
        */
       horizontal: {
         type: Boolean,
@@ -99,8 +97,6 @@ and instead put a div inside and style that.
        * Set opened to true to show the collapse element and to false to hide it.
        *
        * @attribute opened
-       * @type Boolean
-       * @default false
        */
       opened: {
         type: Boolean,


### PR DESCRIPTION
Capitalized "Boolean" is not a type the compiler understands. In this case, the @type also isn't needed because it's the same as the type in the property block.