### PR TITLE
Add iron-collapse-resize event on transitionEnd

### DIFF
--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -82,6 +82,13 @@ and instead put a div inside and style that.
 
     is: 'iron-collapse',
 
+    /**
+     * Fired when the target element has been resized as a result of the opened
+     * state changing.
+     *
+     * @event iron-collapse-resize
+     */
+
     properties: {
 
       /**
@@ -184,6 +191,8 @@ and instead put a div inside and style that.
       this.toggleClass('iron-collapse-closed', !this.opened);
       this.toggleClass('iron-collapse-opened', this.opened);
       this.enableTransition(false);
+
+      this.fire('iron-collapse-resize', this.opened);
     },
 
     _calcSize: function() {


### PR DESCRIPTION
In 0.5 a `core-resize` event was triggered once the transition ended.
It was super useful if you wanted to chain something once the animation was finished.

This PR restores the event but I renamed it `iron-collapse-resize` instead of `iron-resize` to prevent collisions using the element name as a namespace.
I don't know if it's the canonical way though :)