### PR TITLE
Readme fix: Correction for the event binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 will be collapsed.  Use `opened` or `toggle()` to show/hide the content.
 
 ```html
-<button on-click="{{toggle}}">toggle collapse</button>
+<button on-click="toggle">toggle collapse</button>
 
 <iron-collapse id="collapse">
   <div>Content goes here...</div>


### PR DESCRIPTION
No need of {{}} because It's not a data binding but an event name.