### PR TITLE
Remove tabindex hostAttribute, making iron-collapse non-focusable

### DIFF
--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -111,8 +111,7 @@ and instead put a div inside and style that.
 
     hostAttributes: {
       role: 'group',
-      'aria-expanded': 'false',
-      tabindex: 0
+      'aria-expanded': 'false'
     },
 
     listeners: {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-collapse/issues/10