### PR TITLE
call transitionend callback when animation cannot be triggered (e.g. before element is ready)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -44,12 +44,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         border-bottom-right-radius: 5px;
       }
 
+      #collapse3 {
+        max-height: 160px;
+      }
+
     </style>
 
   </head>
   <body unresolved>
   <template is="dom-bind">
-    
+
     <button class="heading" aria-expanded$="[[isExpanded(opened1)]]" aria-controls="collapse1" onclick="toggle('#collapse1')">Collapse #1</button>
 
     <iron-collapse id="collapse1" tabindex="0" opened="{{opened1}}">
@@ -64,9 +68,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div class="content">
         <div>Pro saepe pertinax ei, ad pri animal labores suscipiantur. Modus commodo minimum eum te, vero utinam assueverit per eu, zril oportere suscipiantur pri te. Partem percipitur deterruisset ad sea, at eam suas luptatum dissentiunt. No error alienum pro, erant senserit ex mei, pri semper alterum no. Ut habemus menandri vulputate mea. Feugiat verterem ut sed. Dolores maiestatis id per. Pro saepe pertinax ei, ad pri animal labores suscipiantur. Modus commodo minimum eum te, vero utinam assueverit per eu, zril oportere suscipiantur pri te. Partem percipitur deterruisset ad sea, at eam suas luptatum dissentiunt. No error alienum pro, erant senserit ex mei, pri semper alterum no. Ut habemus menandri vulputate mea. Feugiat verterem ut sed. Dolores maiestatis id per.</div>
 
-        <button class="heading" aria-expanded$="[[isExpanded(opened3)]]" aria-controls="collapse3"  onclick="toggle('#collapse3')">Collapse #3</button>
+        <button class="heading" aria-expanded$="[[isExpanded(opened3)]]" aria-controls="collapse3"  onclick="toggle('#collapse3')">Collapse #3 (horizontal)</button>
 
-        <iron-collapse id="collapse3" tabindex="0" opened="{{opened3}}">
+        <iron-collapse id="collapse3" tabindex="0" opened="{{opened3}}" horizontal>
           <div class="content">
             <div>Iisque perfecto dissentiet cum et, sit ut quot mandamus, ut vim tibique splendide instructior. Id nam odio natum malorum, tibique copiosae expetenda mel ea. Mea melius malorum ut. Ut nec tollit vocent timeam. Facer nonumy numquam id his, munere salutatus consequuntur eum et, eum cotidieque definitionem signiferumque id. Ei oblique graecis patrioque vis, et probatus dignissim inciderint vel. Sed id paulo erroribus, autem semper accusamus in mel. Iisque perfecto dissentiet cum et, sit ut quot mandamus, ut vim tibique splendide instructior. Id nam odio natum malorum, tibique copiosae expetenda mel ea. Mea melius malorum ut. Ut nec tollit vocent timeam. Facer nonumy numquam id his, munere salutatus consequuntur eum et, eum cotidieque definitionem signiferumque id. Ei oblique graecis patrioque vis, et probatus dignissim inciderint vel. Sed id paulo erroribus, autem semper accusamus in mel.</div>
           </div>

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -134,11 +134,11 @@ and instead put a div inside and style that.
     },
 
     show: function() {
-      this.opened = true;    
+      this.opened = true;
     },
 
     hide: function() {
-      this.opened = false;    
+      this.opened = false;
     },
 
     updateSize: function(size, animated) {
@@ -146,7 +146,7 @@ and instead put a div inside and style that.
       var s = this.style;
       var nochange = s[this.dimension] === size;
       s[this.dimension] = size;
-      if (animated && nochange) {
+      if (animated && (nochange || !this._enableTransition)) {
         this._transitionEnd();
       }
     },
@@ -197,8 +197,7 @@ and instead put a div inside and style that.
 
     _calcSize: function() {
       return this.getBoundingClientRect()[this.dimension] + 'px';
-    },
-
+    }
 
   });
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -28,8 +28,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <test-fixture id="test">
       <template>
         <iron-collapse id="collapse" opened>
-          <div>
-            Forma temperiemque cornua sidera dissociata cornua recessit innabilis ligavit: solidumque coeptis nullus caelum sponte phoebe di regat mentisque tanta austro capacius amphitrite sui quin postquam semina fossae liquidum umor galeae coeptis caligine liberioris quin liquidum matutinis invasit posset: flexi glomeravit radiis certis invasit oppida postquam onerosior inclusum dominari opifex terris pace finxit quam aquae nunc sine altae auroram quam habentem homo totidemque scythiam in pondus ensis tegit caecoque poena lapidosos humanas coeperunt poena aetas totidem nec natura aethera locavit caelumque distinxit animalibus phoebe cingebant moderantum porrexerat terrae possedit sua sole diu summaque obliquis melioris orbem
+          <div style="height:100px;">
+            Lorem ipsum
           </div>
         </iron-collapse>
       </template>
@@ -40,11 +40,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('basic', function() {
 
         var collapse;
-        var delay = 500;
         var collapseHeight;
 
-        setup(function () {
+        setup(function() {
           collapse = fixture('test');
+          collapseHeight = getComputedStyle(collapse).height;
         });
 
         test('opened attribute', function() {
@@ -55,34 +55,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(collapse.horizontal, false);
         });
 
-        test('default opened height', function(done) {
-          setTimeout(function() {
-            // store height
-            collapseHeight = getComputedStyle(collapse).height;
-            // verify height not 0px
-            assert.notEqual(collapseHeight, '0px');
-            done();
-          }, delay);
+        test('default opened height', function() {
+          assert.equal(collapse.style.height, 'auto');
         });
 
-        test('set opened to false', function(done) {
+        test('set opened to false triggers animation', function(done) {
           collapse.opened = false;
-          setTimeout(function() {
-            var h = getComputedStyle(collapse).height;
-            // verify height is 0px
-            assert.equal(h, '0px');
+          // animation got enabled
+          assert.notEqual(collapse.style.transitionDuration, '0s');
+          collapse.addEventListener('transitionend', function() {
+            // animation disabled
+            assert.equal(collapse.style.transitionDuration, '0s');
             done();
-          }, delay);
+          });
         });
 
-        test('set opened to true', function(done) {
-          collapse.opened = true;
-          setTimeout(function() {
-            var h = getComputedStyle(collapse).height;
-            // verify height
-            assert.equal(h, collapseHeight);
-            done();
-          }, delay);
+        test('set opened to false, then to true', function(done) {
+          // this listener will be triggered twice (every time `opened` changes)
+          collapse.addEventListener('transitionend', function() {
+            if (collapse.opened) {
+              // check finalSize after animation is done
+              assert.equal(collapse.style.height, 'auto');
+              done();
+            } else {
+              // check if size is still 0px
+              assert.equal(collapse.style.height, '0px');
+              // trigger 2nd toggle
+              collapse.opened = true;
+              // size should be immediately set
+              assert.equal(collapse.style.height, collapseHeight);
+            }
+          });
+          // trigger 1st toggle
+          collapse.opened = false;
+          // size should be immediately set
+          assert.equal(collapse.style.height, '0px');
         });
 
       });

--- a/test/horizontal.html
+++ b/test/horizontal.html
@@ -26,8 +26,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <test-fixture id="test">
       <template>
         <iron-collapse id="collapse" opened horizontal>
-          <div>
-            Forma temperiemque cornua sidera dissociata cornua recessit innabilis ligavit: solidumque coeptis nullus caelum sponte phoebe di regat mentisque tanta austro capacius amphitrite sui quin postquam semina fossae liquidum umor galeae coeptis caligine liberioris quin liquidum matutinis invasit posset: flexi glomeravit radiis certis invasit oppida postquam onerosior inclusum dominari opifex terris pace finxit quam aquae nunc sine altae auroram quam habentem homo totidemque scythiam in pondus ensis tegit caecoque poena lapidosos humanas coeperunt poena aetas totidem nec natura aethera locavit caelumque distinxit animalibus phoebe cingebant moderantum porrexerat terrae possedit sua sole diu summaque obliquis melioris orbem
+          <div style="width:100px;">
+            Lorem ipsum
           </div>
         </iron-collapse>
       </template>
@@ -38,11 +38,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('horizontal', function() {
 
         var collapse;
-        var delay = 500;
-        var collapseHeight;
+        var collapseWidth;
 
         setup(function () {
           collapse = fixture('test');
+          collapseWidth = getComputedStyle(collapse).width;
         });
 
         test('opened attribute', function() {
@@ -53,36 +53,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(collapse.horizontal, true);
         });
 
-        test('default opened width', function(done) {
-          setTimeout(function() {
-            // store actual width
-            width = getComputedStyle(collapse).width;
-            // verify width not 0px
-            assert.notEqual(width, '0px');
-            done();
-          }, delay);
+        test('default opened width', function() {
+          assert.equal(collapse.style.width, 'auto');
         });
 
-        test('set opened to false', function(done) {
+        test('set opened to false, then to true', function(done) {
+          // this listener will be triggered twice (every time `opened` changes)
+          collapse.addEventListener('transitionend', function() {
+            if (collapse.opened) {
+              // check finalSize after animation is done
+              assert.equal(collapse.style.width, 'auto');
+              done();
+            } else {
+              // check if size is still 0px
+              assert.equal(collapse.style.width, '0px');
+              // trigger 2nd toggle
+              collapse.opened = true;
+              // size should be immediately set
+              assert.equal(collapse.style.width, collapseWidth);
+            }
+          });
+          // trigger 1st toggle
           collapse.opened = false;
-          setTimeout(function() {
-            var h = getComputedStyle(collapse).width;
-            // verify width is 0px
-            assert.equal(h, '0px');
-            done();
-          }, delay);
+          // size should be immediately set
+          assert.equal(collapse.style.width, '0px');
         });
-
-        test('set opened to true', function(done) {
-          collapse.opened = true;
-          setTimeout(function() {
-            var h = getComputedStyle(collapse).width;
-            // verify width
-            assert.equal(h, width);
-            done();
-          }, delay);
-        });
-
       });
 
     </script>


### PR DESCRIPTION
Fixes #24 by calling transitionend callback when animation cannot be triggered (e.g. before element is ready)