### PR TITLE
force layout, avoid line removal by compilers

### DIFF
--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -166,8 +166,9 @@ and instead put a div inside and style that.
         }
         // Go to startSize without animation.
         this.style[this.dimension] = startSize;
-        // Force layout to ensure transition will go.
-        /** @suppress {suspiciousCode} */ this.offsetHeight;
+        // Force layout to ensure transition will go. Set offsetHeight to itself
+        // so that compilers won't remove it.
+        this.offsetHeight = this.offsetHeight;
         // Enable animation.
         this._updateTransition(true);
       }


### PR DESCRIPTION
Fixes #34 by setting offsetHeight to itself. This way compilers won't remove this line.
Here an example (click on "Compile")
https://closure-compiler.appspot.com/home#code%3D%252F%252F%2520%253D%253DClosureCompiler%253D%253D%250A%252F%252F%2520%2540compilation_level%2520ADVANCED_OPTIMIZATIONS%250A%252F%252F%2520%2540output_file_name%2520default.js%250A%252F%252F%2520%2540formatting%2520pretty_print%250A%252F%252F%2520%253D%253D%252FClosureCompiler%253D%253D%250A%250A%252F%252F%2520ADD%2520YOUR%2520CODE%2520HERE%250Afunction%2520hello(name)%2520%257B%250A%2520%2520var%2520a%2520%253D%2520%257Bok%253A1%257D%253B%250A%2520%2520%252F**%2520%2540suppress%2520%257BsuspiciousCode%257D%2520*%252F%2520a.ok%253B%250A%2520%2520a.ok%2520%253D%2520a.ok%253B%250A%2520%2520alert('Hello%252C%2520'%2520%252B%2520name%2520%252B%2520a)%253B%250A%257D%250Ahello('New%2520user')%253B%250A