### PR TITLE
allow overflow to be visible when collapse is opened

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -19,9 +19,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="../iron-collapse.html">
+    <link rel="import" href="../../paper-styles/shadow.html">
     <link rel="stylesheet" href="../../paper-styles/demo.css">
 
-    <style>
+    <style is="custom-style">
       .heading {
         padding: 10px 15px;
         margin-top: 20px;
@@ -42,6 +43,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         border-top: none;
         border-bottom-left-radius: 5px;
         border-bottom-right-radius: 5px;
+        @apply(--shadow-elevation-2dp);
       }
 
       #collapse3 {

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -57,11 +57,15 @@ and instead put a div inside and style that.
     :host {
       display: block;
       transition-duration: 300ms;
-      overflow: auto;
+      overflow: visible;
     }
 
     :host(.iron-collapse-closed) {
       display: none;
+    }
+
+    :host(:not(.iron-collapse-opened)) {
+      overflow: hidden;
     }
 
   </style>

--- a/test/basic.html
+++ b/test/basic.html
@@ -114,6 +114,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.isTrue(spy.calledOnce, 'iron-resize was fired');
         });
 
+        test('overflow is hidden while animating', function(done) {
+          collapse.addEventListener('transitionend', function() {
+            // Should still be hidden.
+            assert.equal(getComputedStyle(collapse).overflow, 'hidden');
+            done();
+          });
+          assert.equal(getComputedStyle(collapse).overflow, 'visible');
+          collapse.opened = false;
+          // Immediately updated style.
+          assert.equal(getComputedStyle(collapse).overflow, 'hidden');
+        });
+
       });
 
     </script>


### PR DESCRIPTION
Fixes #38, Fixes #40 by allowing overflow to be visible when collapse is opened, and hidden while animating.