### PR TITLE
implement iron-resizable-behavior and call notifyResize when opened change

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/PolymerElements/iron-collapse",
   "ignore": [],
   "dependencies": {
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 
 <!--
 `iron-collapse` creates a collapsible block of content.  By default, the content
@@ -78,6 +79,10 @@ and instead put a div inside and style that.
   Polymer({
 
     is: 'iron-collapse',
+
+    behaviors: [
+      Polymer.IronResizableBehavior
+    ],
 
     properties: {
 
@@ -221,6 +226,7 @@ and instead put a div inside and style that.
       this.toggleClass('iron-collapse-closed', !this.opened);
       this.toggleClass('iron-collapse-opened', this.opened);
       this._updateTransition(false);
+      this.notifyResize();
     },
 
     _calcSize: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -105,6 +105,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(collapse.style.height, '0px');
         });
 
+        test('opened changes trigger iron-resize', function() {
+          var spy = sinon.stub();
+          collapse.addEventListener('iron-resize', spy);
+          // No animations for faster test.
+          collapse.noAnimation = true;
+          collapse.opened = false;
+          assert.isTrue(spy.calledOnce, 'iron-resize was fired');
+        });
+
       });
 
     </script>


### PR DESCRIPTION
Fixes #37 by implementing `iron-resizable-behavior` and calling `notifyResize` once the transition is done (this happens when `opened` changes)