### PR TITLE
Fix #48: correctly handle expansion of hidden nested iron-collapse

### DIFF
--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -168,7 +168,7 @@ and instead put a div inside and style that.
 
       this._updateTransition(false);
       // If we can animate, must do some prep work.
-      if (animated && !this.noAnimation && this._isVisible()) {
+      if (animated && !this.noAnimation && this._isDisplayed) {
         // Animation will start at the current size.
         var startSize = this._calcSize();
         // For `auto` we must calculate what is the final size for the animation.
@@ -239,7 +239,12 @@ and instead put a div inside and style that.
       this.notifyResize();
     },
 
-    _isVisible: function() {
+    /**
+     * Simplistic heuristic to detect if element has a parent with display: none
+     *
+     * @private
+     */
+    get _isDisplayed() {
       var rect = this.getBoundingClientRect();
       for (prop in rect) {
         if (rect[prop] !== 0) return true;

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -168,7 +168,7 @@ and instead put a div inside and style that.
 
       this._updateTransition(false);
       // If we can animate, must do some prep work.
-      if (animated && !this.noAnimation) {
+      if (animated && !this.noAnimation && this._isVisible()) {
         // Animation will start at the current size.
         var startSize = this._calcSize();
         // For `auto` we must calculate what is the final size for the animation.
@@ -237,6 +237,14 @@ and instead put a div inside and style that.
       this.toggleClass('iron-collapse-opened', this.opened);
       this._updateTransition(false);
       this.notifyResize();
+    },
+
+    _isVisible: function() {
+      var rect = this.getBoundingClientRect();
+      for (prop in rect) {
+        if (rect[prop] !== 0) return true;
+      }
+      return false;
     },
 
     _calcSize: function() {

--- a/test/index.html
+++ b/test/index.html
@@ -20,9 +20,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'basic.html',
         'horizontal.html',
         'a11y.html',
+        'nested.html',
         'basic.html?dom=shadow',
         'horizontal.html?dom=shadow',
-        'a11y.html?dom=shadow'
+        'a11y.html?dom=shadow',
+        'nested.html?dom=shadow'
       ]);
     </script>
 

--- a/test/nested.html
+++ b/test/nested.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html>
+  <head>
+    <title>iron-collapse-nested</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+    <link rel="import" href="../../test-fixture/test-fixture.html">
+    <link rel="import" href="../iron-collapse.html">
+  </head>
+  <body>
+
+    <test-fixture id="test">
+      <template>
+        <iron-collapse id="outer-collapse">
+          <div style="height:100px;">
+            Lorem ipsum
+          </div>
+
+          <iron-collapse id="inner-collapse">
+            <div style="height:100px;">
+              consectetur adipiscing elit
+            </div>
+          </iron-collapse>
+        </iron-collapse>
+      </template>
+    </test-fixture>
+
+    <script>
+
+      suite('nested', function() {
+
+        var outerCollapse;
+        var innerCollapse;
+
+        setup(function () {
+          outerCollapse = fixture('test');
+          innerCollapse = outerCollapse.querySelector('#inner-collapse');
+        });
+
+        suite('closed outer collapse', function() {
+
+          test('inner collapse default opened attribute', function() {
+            assert.equal(innerCollapse.opened, false);
+          });
+
+          test('inner collapse default style height', function() {
+            assert.equal(innerCollapse.style.height, '0px');
+          });
+
+          test('set inner opened to true updates inner style height without animation', function() {
+            innerCollapse.opened = true;
+
+            // Animation disabled and height expanded
+            assert.equal(innerCollapse.style.transitionDuration, '0s');
+            assert.equal(innerCollapse.style.height, 'auto');
+          });
+
+        });
+
+        suite('opened outer collapse', function() {
+
+          setup(function () {
+            outerCollapse.opened = true;
+          });
+
+          test('inner collapse default opened attribute', function() {
+            assert.equal(innerCollapse.opened, false);
+          });
+
+          test('inner collapse default style height', function() {
+            assert.equal(innerCollapse.style.height, '0px');
+          });
+
+          test('set inner opened to true triggers height animation', function() {
+            innerCollapse.opened = true;
+
+            // Animation got enabled and target height set
+            assert.notEqual(innerCollapse.style.transitionDuration, '0s');
+            assert.equal(innerCollapse.style.height, '100px');
+
+            innerCollapse.addEventListener('transitionend', function() {
+              // Animation disabled.
+              assert.equal(innerCollapse.style.transitionDuration, '0s');
+              done();
+            });
+          });
+
+        });
+      });
+    </script>
+
+  </body>
+</html>

--- a/test/nested.html
+++ b/test/nested.html
@@ -62,42 +62,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(innerCollapse.style.height, '0px');
           });
 
-          test('set inner opened to true updates inner style height without animation', function() {
+          test('open inner collapse updates size without animation', function() {
             innerCollapse.opened = true;
 
-            // Animation disabled and height expanded
+            // Animation disabled
             assert.equal(innerCollapse.style.transitionDuration, '0s');
-            assert.equal(innerCollapse.style.height, 'auto');
           });
 
-        });
-
-        suite('opened outer collapse', function() {
-
-          setup(function () {
-            outerCollapse.opened = true;
-          });
-
-          test('inner collapse default opened attribute', function() {
-            assert.equal(innerCollapse.opened, false);
-          });
-
-          test('inner collapse default style height', function() {
-            assert.equal(innerCollapse.style.height, '0px');
-          });
-
-          test('set inner opened to true triggers height animation', function() {
+          test('open inner collapse then open outer collapse reveals expanded inner collapse', function() {
             innerCollapse.opened = true;
+            outerCollapse.opened = true;
 
-            // Animation got enabled and target height set
-            assert.notEqual(innerCollapse.style.transitionDuration, '0s');
-            assert.equal(innerCollapse.style.height, '100px');
-
-            innerCollapse.addEventListener('transitionend', function() {
-              // Animation disabled.
-              assert.equal(innerCollapse.style.transitionDuration, '0s');
-              done();
-            });
+            assert.equal(innerCollapse.getBoundingClientRect().height, 100);
           });
 
         });

--- a/test/nested.html
+++ b/test/nested.html
@@ -31,8 +31,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Lorem ipsum
           </div>
 
-          <iron-collapse id="inner-collapse">
+          <iron-collapse id="inner-collapse-vertical">
             <div style="height:100px;">
+              consectetur adipiscing elit
+            </div>
+          </iron-collapse>
+
+          <iron-collapse id="inner-collapse-horizontal" horizontal style="display: inline-block">
+            <div style="width:100px;">
               consectetur adipiscing elit
             </div>
           </iron-collapse>
@@ -49,10 +55,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         setup(function () {
           outerCollapse = fixture('test');
-          innerCollapse = outerCollapse.querySelector('#inner-collapse');
         });
 
-        suite('closed outer collapse', function() {
+        suite('vertical', function() {
+
+          setup(function () {
+            innerCollapse = outerCollapse.querySelector('#inner-collapse-vertical');
+          });
 
           test('inner collapse default opened attribute', function() {
             assert.equal(innerCollapse.opened, false);
@@ -69,11 +78,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(innerCollapse.style.transitionDuration, '0s');
           });
 
-          test('open inner collapse then open outer collapse reveals expanded inner collapse', function() {
+          test('open inner collapse then open outer collapse reveals inner collapse with expanded height', function() {
             innerCollapse.opened = true;
             outerCollapse.opened = true;
 
             assert.equal(innerCollapse.getBoundingClientRect().height, 100);
+          });
+
+        });
+
+        suite('horizontal', function() {
+
+          setup(function () {
+            innerCollapse = outerCollapse.querySelector('#inner-collapse-horizontal');
+          });
+
+          test('inner collapse default style width', function() {
+            assert.equal(innerCollapse.style.width, '0px');
+          });
+
+          test('open inner collapse updates size without animation', function() {
+            innerCollapse.opened = true;
+
+            // Animation disabled
+            assert.equal(innerCollapse.style.transitionDuration, '0s');
+          });
+
+          test('open inner collapse then open outer collapse reveals inner collapse with expanded width', function() {
+            innerCollapse.opened = true;
+            outerCollapse.opened = true;
+
+            assert.equal(innerCollapse.getBoundingClientRect().width, 100);
           });
 
         });


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-collapse/issues/48 by disabling the problematic animation code when the element is hidden.

Note that I've used a fairly silly heuristic to determine whether the current element is rendered or not. If there's a better way to do this, please let me know!