### PR TITLE
use scrollTop for forcing reflow.

### DIFF
--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -129,7 +129,7 @@ and instead put a div inside and style that.
     /**
      * `maxWidth` or `maxHeight`.
      * @private
-     */    
+     */
     get _dimensionMax() {
       return this.horizontal ? 'maxWidth' : 'maxHeight';
     },
@@ -178,7 +178,7 @@ and instead put a div inside and style that.
      * Updates the size of the element.
      * @param {string} size The new value for `maxWidth`/`maxHeight` as css property value, usually `auto` or `0px`.
      * @param {boolean=} animated if `true` updates the size with an animation, otherwise without.
-     */     
+     */
     updateSize: function(size, animated) {
       // No change!
       var curSize = this.style[this._dimensionMax];
@@ -199,9 +199,9 @@ and instead put a div inside and style that.
         }
         // Go to startSize without animation.
         this.style[this._dimensionMax] = startSize;
-        // Force layout to ensure transition will go. Set offsetHeight to itself
+        // Force layout to ensure transition will go. Set scrollTop to itself
         // so that compilers won't remove it.
-        this.offsetHeight = this.offsetHeight;
+        this.scrollTop = this.scrollTop;
         // Enable animation.
         this._updateTransition(true);
       }


### PR DESCRIPTION
Fixes #58 by using `scrollTop` instead of `offsetHeight` to force a reflow. `scrollTop` can be set, while `offsetHeight` is readonly.