### PR TITLE
call _transitionEnd if no transition is performed, styles need to be set

### DIFF
--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -127,15 +127,15 @@ Custom property | Description | Default
       noAnimation: {
         type: Boolean
       },
-	  
-	  /**
+
+      /**
        * stores the desired size of the collapse body
-       *
-	   */
-	  _desiredSize: {
-		type: String,
-		value: ""
-	  }
+       * @private
+       */
+      _desiredSize: {
+        type: String,
+        value: ""
+      }
     },
 
     get dimension() {
@@ -197,13 +197,13 @@ Custom property | Description | Default
      */
     updateSize: function(size, animated) {
       // Consider 'auto' as '', to take full size.
-	  size = size === 'auto' ? '' : size;
-	  // No change!
-	  if (this._desiredSize === size) {
-		return;
-	  }
-	  
-	  this._desiredSize = size;
+      size = size === 'auto' ? '' : size;
+      // No change!
+      if (this._desiredSize === size) {
+        return;
+      }
+
+      this._desiredSize = size;
 
       this._updateTransition(false);
       var willAnimate = animated && !this.noAnimation && this._isDisplayed;
@@ -273,9 +273,7 @@ Custom property | Description | Default
     },
 
     _transitionEnd: function() {
-      if (this.opened) {
-        this.style[this._dimensionMax] = this._desiredSize;
-      }
+      this.style[this._dimensionMax] = this._desiredSize;
       this.toggleClass('iron-collapse-closed', !this.opened);
       this.toggleClass('iron-collapse-opened', this.opened);
       this._updateTransition(false);

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -216,6 +216,9 @@ Custom property | Description | Default
       // Set the final size.
       if (size === 'auto') {
         this.style[this._dimensionMax] = '';
+      // call _transitionEnd if no transition is performed, styles need to be set
+      } else if (size === startSize) {
+        this._transitionEnd();
       } else {
         this.style[this._dimensionMax] = size;
       }

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -120,7 +120,7 @@ Custom property | Description | Default
       },
 
       /**
-       * Set noAnimation to true to disable animations
+       * Set noAnimation to true to disable animations.
        *
        * @attribute noAnimation
        */
@@ -129,12 +129,12 @@ Custom property | Description | Default
       },
 
       /**
-       * stores the desired size of the collapse body
+       * Stores the desired size of the collapse body.
        * @private
        */
       _desiredSize: {
         type: String,
-        value: ""
+        value: ''
       }
     },
 

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -127,7 +127,15 @@ Custom property | Description | Default
       noAnimation: {
         type: Boolean
       },
-
+	  
+	  /**
+       * stores the desired size of the collapse body
+       *
+	   */
+	  _desiredSize: {
+		type: String,
+		value: ""
+	  }
     },
 
     get dimension() {
@@ -188,20 +196,24 @@ Custom property | Description | Default
      * @param {boolean=} animated if `true` updates the size with an animation, otherwise without.
      */
     updateSize: function(size, animated) {
-      // No change!
-      var curSize = this.style[this._dimensionMax];
-      if (curSize === size || (size === 'auto' && !curSize)) {
-        return;
-      }
+      // Consider 'auto' as '', to take full size.
+	  size = size === 'auto' ? '' : size;
+	  // No change!
+	  if (this._desiredSize === size) {
+		return;
+	  }
+	  
+	  this._desiredSize = size;
 
       this._updateTransition(false);
+      var willAnimate = animated && !this.noAnimation && this._isDisplayed;
       // If we can animate, must do some prep work.
-      if (animated && !this.noAnimation && this._isDisplayed) {
+      if (willAnimate) {
         // Animation will start at the current size.
         var startSize = this._calcSize();
         // For `auto` we must calculate what is the final size for the animation.
         // After the transition is done, _transitionEnd will set the size back to `auto`.
-        if (size === 'auto') {
+        if (size === '') {
           this.style[this._dimensionMax] = '';
           size = this._calcSize();
         }
@@ -212,15 +224,14 @@ Custom property | Description | Default
         this.scrollTop = this.scrollTop;
         // Enable animation.
         this._updateTransition(true);
+        // If final size is the same as startSize it will not animate.
+        willAnimate = (size !== startSize);
       }
       // Set the final size.
-      if (size === 'auto') {
-        this.style[this._dimensionMax] = '';
-      // call _transitionEnd if no transition is performed, styles need to be set
-      } else if (size === startSize) {
+      this.style[this._dimensionMax] = size;
+      // If it won't animate, call transitionEnd to set correct classes.
+      if (!willAnimate) {
         this._transitionEnd();
-      } else {
-        this.style[this._dimensionMax] = size;
       }
     },
 
@@ -259,14 +270,11 @@ Custom property | Description | Default
       if (this.opened) {
         this.focus();
       }
-      if (this.noAnimation) {
-        this._transitionEnd();
-      }
     },
 
     _transitionEnd: function() {
       if (this.opened) {
-        this.style[this._dimensionMax] = '';
+        this.style[this._dimensionMax] = this._desiredSize;
       }
       this.toggleClass('iron-collapse-closed', !this.opened);
       this.toggleClass('iron-collapse-opened', this.opened);

--- a/test/basic.html
+++ b/test/basic.html
@@ -35,6 +35,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </iron-collapse>
       </template>
     </test-fixture>
+	
+	
+	<test-fixture id="test-empty">
+	<template>
+        <iron-collapse id="collapse" opened>
+        </iron-collapse>
+      </template>
+	</test-fixture>
 
     <script>
 
@@ -140,6 +148,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
       });
+	  
+	  suite('empty', function() {
+
+        var collapse;
+
+        setup(function() {
+		  collapse = fixture('test-empty');
+		  
+        });
+
+        test('empty&opened shows dynamically loaded content', function(done) {
+			flush(function () {
+				collapse.toggle();
+				collapse.toggle();
+				assert.equal(collapse.style.maxHeight, "");
+				done();
+			});
+        });
+		
+		});
 
     </script>
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -35,14 +35,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </iron-collapse>
       </template>
     </test-fixture>
-	
-	
-	<test-fixture id="test-empty">
-	<template>
+
+    <test-fixture id="test-empty">
+    <template>
         <iron-collapse id="collapse" opened>
         </iron-collapse>
       </template>
-	</test-fixture>
+    </test-fixture>
 
     <script>
 
@@ -146,37 +145,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(collapse.style.height, '');
           assert.equal(collapse.style.transitionProperty, 'max-width');
         });
-		
-		test('change size with updateSize', function(done) {
-			collapse.addEventListener('transitionend', function() {
-				// size should be kept after transition
-				assert.equal(collapse.style.maxHeight, "123px");
-				done();
-			});
-			collapse.updateSize("123px", true);
-		});
+
+        test('change size with updateSize', function(done) {
+          collapse.addEventListener('transitionend', function() {
+            // size should be kept after transition
+            assert.equal(collapse.style.maxHeight, "123px");
+            done();
+          });
+          collapse.updateSize("123px", true);
+        });
 
       });
-	  
-	  suite('empty', function() {
+
+      suite('empty', function() {
 
         var collapse;
 
         setup(function() {
-		  collapse = fixture('test-empty');
-		  
+          collapse = fixture('test-empty');
         });
 
         test('empty&opened shows dynamically loaded content', function(done) {
-			flush(function () {
-				collapse.toggle();
-				collapse.toggle();
-				assert.equal(collapse.style.maxHeight, "");
-				done();
-			});
+          flush(function () {
+            collapse.toggle();
+            collapse.toggle();
+            assert.equal(collapse.style.maxHeight, "");
+            done();
+          });
         });
-		
-		});
+
+      });
 
     </script>
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -146,6 +146,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(collapse.style.height, '');
           assert.equal(collapse.style.transitionProperty, 'max-width');
         });
+		
+		test('change size with updateSize', function(done) {
+			collapse.addEventListener('transitionend', function() {
+				// size should be kept after transition
+				assert.equal(collapse.style.maxHeight, "123px");
+				done();
+			});
+			collapse.updateSize("123px", true);
+		});
 
       });
 	  

--- a/test/flex.html
+++ b/test/flex.html
@@ -134,15 +134,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(collapse.style.height, '');
           assert.equal(collapse.style.transitionProperty, 'max-width');
         });
-		
-		test('change size with updateSize', function(done) {
-			collapse.addEventListener('transitionend', function() {
-				// size should be kept after transition
-				assert.equal(collapse.style.maxHeight, "123px");
-				done();
-			});
-			collapse.updateSize("123px", true);
-		});
+
+        test('change size with updateSize', function(done) {
+          collapse.addEventListener('transitionend', function() {
+            // size should be kept after transition
+            assert.equal(collapse.style.maxHeight, "123px");
+            done();
+          });
+          collapse.updateSize("123px", true);
+        });
 
       });
 

--- a/test/flex.html
+++ b/test/flex.html
@@ -134,6 +134,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(collapse.style.height, '');
           assert.equal(collapse.style.transitionProperty, 'max-width');
         });
+		
+		test('change size with updateSize', function(done) {
+			collapse.addEventListener('transitionend', function() {
+				// size should be kept after transition
+				assert.equal(collapse.style.maxHeight, "123px");
+				done();
+			});
+			collapse.updateSize("123px", true);
+		});
 
       });
 

--- a/test/horizontal.html
+++ b/test/horizontal.html
@@ -79,7 +79,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // Size should be immediately set.
           assert.equal(collapse.style.maxWidth, '0px');
         });
+		
+		test('change size with updateSize', function(done) {
+			collapse.addEventListener('transitionend', function() {
+				// size should be kept after transition
+				assert.equal(collapse.style.maxWidth, "123px");
+				done();
+			});
+			collapse.updateSize("123px", true);
+		});
+		
       });
+	  
+	  
 
     </script>
 

--- a/test/horizontal.html
+++ b/test/horizontal.html
@@ -79,19 +79,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // Size should be immediately set.
           assert.equal(collapse.style.maxWidth, '0px');
         });
-		
-		test('change size with updateSize', function(done) {
-			collapse.addEventListener('transitionend', function() {
-				// size should be kept after transition
-				assert.equal(collapse.style.maxWidth, "123px");
-				done();
-			});
-			collapse.updateSize("123px", true);
-		});
-		
+
+        test('change size with updateSize', function(done) {
+          collapse.addEventListener('transitionend', function() {
+            // size should be kept after transition
+            assert.equal(collapse.style.maxWidth, "123px");
+            done();
+          });
+          collapse.updateSize("123px", true);
+        });
+
       });
-	  
-	  
 
     </script>
 


### PR DESCRIPTION
This fixes the following problem:

An opened iron-collapse with no content sets style fixed as "max-height: 0px", since the transition is from 0px->0px and thus _transitionEnd is not fired. When the iron-collapse receives content, it won't be displayed even thoug the iron-collapse is opened.

Fixes https://github.com/PolymerElements/iron-collapse/issues/64, fixes https://github.com/PolymerElements/iron-collapse/issues/65 (added by @valdrinkoshi)