### PR TITLE
2.0 preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bower_components
+bower_components*
+bower-*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 sudo: required
 before_script:
-  - npm install -g bower polymer-cli@next
+  - npm install -g polymer-cli
   - polymer install --variants
-  - sudo mv /usr/bin/google-chrome /usr/bin/google-chrome-old
-  - sudo mv /usr/bin/google-chrome-beta /usr/bin/google-chrome
 env:
   global:
     - secure: >-
@@ -18,7 +16,7 @@ addons:
     sources:
       - google-chrome
     packages:
-      - google-chrome-beta
+      - google-chrome-stable
 script:
   - xvfb-run polymer test
   - >-

--- a/README.md
+++ b/README.md
@@ -1,23 +1,9 @@
-
-<!---
-
-This README is automatically generated from the comments in these files:
-iron-collapse.html
-
-Edit those files, and our readme bot will duplicate them over here!
-Edit this file, and the bot will squash your changes :)
-
-The bot does some handling of markdown. Please file a bug if it does the wrong
-thing! https://github.com/PolymerLabs/tedium/issues
-
--->
-
 [![Build status](https://travis-ci.org/PolymerElements/iron-collapse.svg?branch=master)](https://travis-ci.org/PolymerElements/iron-collapse)
 
 _[Demo and API docs](https://elements.polymer-project.org/elements/iron-collapse)_
 
 
-##&lt;iron-collapse&gt;
+## &lt;iron-collapse&gt;
 
 `iron-collapse` creates a collapsible block of content.  By default, the content
 will be collapsed.  Use `opened` or `toggle()` to show/hide the content.

--- a/bower.json
+++ b/bower.json
@@ -19,16 +19,23 @@
   "homepage": "https://github.com/PolymerElements/iron-collapse",
   "ignore": [],
   "dependencies": {
-    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0",
-    "polymer": "Polymer/polymer#^1.5.0"
+    "iron-resizable-behavior": "https://github.com/notwaldorf/iron-resizable.git#2.0-preview",
+    "polymer": "https://github.com/PolymerLabs/alacarte.git#master"
   },
   "devDependencies": {
-    "web-component-tester": "^4.0.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-flex-layout": "polymerelements/iron-flex-layout#^1.0.0",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "iron-flex-layout": "https://github.com/notwaldorf/iron-flex-layout.git#2.0-preview",
+    "paper-styles": "https://github.com/notwaldorf/paper-styles.git#2.0-preview",
+    "test-fixture": "PolymerElements/test-fixture#ce-v1",
+    "web-component-tester": "^4.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#v1-polymer-edits"
   },
-  "main": "iron-collapse.html"
+  "main": "iron-collapse.html",
+  "resolutions": {
+    "iron-flex-layout": "2.0-preview",
+    "paper-styles": "2.0-preview",
+    "polymer": "master",
+    "test-fixture": "ce-v1",
+    "webcomponentsjs": "v1-polymer-edits"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -19,23 +19,23 @@
   "homepage": "https://github.com/PolymerElements/iron-collapse",
   "ignore": [],
   "dependencies": {
-    "iron-resizable-behavior": "https://github.com/notwaldorf/iron-resizable-behavior.git#2.0-preview",
-    "polymer": "https://github.com/PolymerLabs/alacarte.git#master"
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#2.0-preview",
+    "polymer": "Polymer/polymer#2.0-preview"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "paper-styles": "https://github.com/notwaldorf/paper-styles.git#2.0-preview",
-    "iron-demo-helpers": "https://github.com/notwaldorf/iron-demo-helpers.git#2.0-preview",
+    "paper-styles": "PolymerElements/paper-styles#2.0-preview",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
     "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
     "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#v1-polymer-edits"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
   },
   "main": "iron-collapse.html",
   "resolutions": {
     "paper-styles": "2.0-preview",
-    "polymer": "master",
+    "polymer": "2.0-preview",
     "test-fixture": "custom-elements-v1",
-    "webcomponentsjs": "v1-polymer-edits",
-    "iron-flex-layout": "2.0-preview"
+    "iron-flex-layout": "2.0-preview",
+    "webcomponentsjs": "v1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,6 @@
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "paper-styles": "PolymerElements/paper-styles#2.0-preview",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1"
   },
@@ -40,7 +39,6 @@
         "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "paper-styles": "PolymerElements/paper-styles#^1.0.0",
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
         "web-component-tester": "^5.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-collapse",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Provides a collapsable container",
   "authors": [
     "The Polymer Authors"
@@ -26,6 +26,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-flex-layout": "https://github.com/notwaldorf/iron-flex-layout.git#2.0-preview",
     "paper-styles": "https://github.com/notwaldorf/paper-styles.git#2.0-preview",
+    "iron-demo-helpers": "https://github.com/notwaldorf/iron-demo-helpers.git#2.0-preview",
     "test-fixture": "PolymerElements/test-fixture#ce-v1",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1-polymer-edits"

--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
         "paper-styles": "PolymerElements/paper-styles#^1.0.0",
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
         "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-        "web-component-tester": "^4.0.0",
+        "web-component-tester": "^5.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       }
     }

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/PolymerElements/iron-collapse",
   "ignore": [],
   "dependencies": {
-    "iron-resizable-behavior": "https://github.com/notwaldorf/iron-resizable.git#2.0-preview",
+    "iron-resizable-behavior": "https://github.com/notwaldorf/iron-resizable-behavior.git#2.0-preview",
     "polymer": "https://github.com/PolymerLabs/alacarte.git#master"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "ignore": [],
   "dependencies": {
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#2.0-preview",
-    "polymer": "Polymer/polymer#2.0-preview"
+    "polymer": "Polymer/polymer#^2.0.0-rc.1"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",

--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,22 @@
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
   },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0",
+        "polymer": "Polymer/polymer#^1.0.0"
+      },
+      "devDependencies": {
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+        "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+        "web-component-tester": "^4.0.0",
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+      }
+    }
+  },
   "main": "iron-collapse.html",
   "resolutions": {
     "paper-styles": "2.0-preview",

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "polymer": "Polymer/polymer#2.0-preview"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "paper-styles": "PolymerElements/paper-styles#2.0-preview",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
     "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
@@ -48,10 +48,6 @@
   },
   "main": "iron-collapse.html",
   "resolutions": {
-    "paper-styles": "2.0-preview",
-    "polymer": "2.0-preview",
-    "test-fixture": "custom-elements-v1",
-    "iron-flex-layout": "2.0-preview",
-    "webcomponentsjs": "v1"
+    "test-fixture": "custom-elements-v1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-flex-layout": "https://github.com/notwaldorf/iron-flex-layout.git#2.0-preview",
     "paper-styles": "https://github.com/notwaldorf/paper-styles.git#2.0-preview",
     "iron-demo-helpers": "https://github.com/notwaldorf/iron-demo-helpers.git#2.0-preview",
     "test-fixture": "PolymerElements/test-fixture#ce-v1",
@@ -33,7 +32,6 @@
   },
   "main": "iron-collapse.html",
   "resolutions": {
-    "iron-flex-layout": "2.0-preview",
     "paper-styles": "2.0-preview",
     "polymer": "master",
     "test-fixture": "ce-v1",

--- a/bower.json
+++ b/bower.json
@@ -26,9 +26,9 @@
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "paper-styles": "PolymerElements/paper-styles#2.0-preview",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#safari9-constructor",
-    "web-component-tester": "v6.0.0-prerelease.5",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
+    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1"
   },
   "variants": {
     "1.x": {
@@ -46,8 +46,5 @@
       }
     }
   },
-  "main": "iron-collapse.html",
-  "resolutions": {
-    "test-fixture": "safari9-constructor"
-  }
+  "main": "iron-collapse.html"
 }

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "paper-styles": "https://github.com/notwaldorf/paper-styles.git#2.0-preview",
     "iron-demo-helpers": "https://github.com/notwaldorf/iron-demo-helpers.git#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#ce-v1",
+    "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1-polymer-edits"
   },
@@ -34,7 +34,8 @@
   "resolutions": {
     "paper-styles": "2.0-preview",
     "polymer": "master",
-    "test-fixture": "ce-v1",
-    "webcomponentsjs": "v1-polymer-edits"
+    "test-fixture": "custom-elements-v1",
+    "webcomponentsjs": "v1-polymer-edits",
+    "iron-flex-layout": "2.0-preview"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "paper-styles": "PolymerElements/paper-styles#2.0-preview",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#^2.0.0",
+    "test-fixture": "PolymerElements/test-fixture#safari9-constructor",
     "web-component-tester": "v6.0.0-prerelease.5",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
   },
@@ -48,6 +48,6 @@
   },
   "main": "iron-collapse.html",
   "resolutions": {
-    "test-fixture": "^2.0.0"
+    "test-fixture": "safari9-constructor"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,6 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
   <link rel="import" href="simple-expand-collapse.html">
 
   <style is="custom-style" include="demo-pages-shared-styles">

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,96 +10,97 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <html>
-  <head>
 
-    <title>iron-collapse demo</title>
+<head>
 
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>iron-collapse demo</title>
 
-    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="../iron-collapse.html">
-    <link rel="import" href="../../paper-styles/shadow.html">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <style is="custom-style">
-      .heading {
-        padding: 10px 15px;
-        margin-top: 20px;
-        background-color: #f3f3f3;
-        border: 1px solid #dedede;
-        border-top-left-radius: 5px;
-        border-top-right-radius: 5px;
-        font-size: 18px;
-        cursor: pointer;
-        -webkit-tap-highlight-color: rgba(0,0,0,0);
-        width: 100%;
-        text-align: left;
-      }
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-      .content {
-        padding: 15px;
-        border: 1px solid #dedede;
-        border-top: none;
-        border-bottom-left-radius: 5px;
-        border-bottom-right-radius: 5px;
-        @apply(--shadow-elevation-2dp);
-      }
+  <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="simple-expand-collapse.html">
 
-      #collapse3 {
+  <style is="custom-style" include="demo-pages-shared-styles">
+
+    demo-snippet {
+      --demo-snippet-code: {
         max-height: 250px;
       }
+    }
 
-    </style>
+    simple-expand-collapse {
+      margin: 10px;
+    }
 
-  </head>
-  <body unresolved>
-    <dom-bind>
-  <template is="dom-bind">
+    .content {
+      padding: 15px;
+    }
+  </style>
 
-    <button class="heading" aria-expanded$="[[isExpanded(opened1)]]" aria-controls="collapse1" onclick="toggle('#collapse1')">Collapse #1</button>
+</head>
 
-    <iron-collapse id="collapse1" tabindex="0" opened="{{opened1}}">
-      <div class="content">
-        <div>Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea, id minim maiestatis incorrupte duo. Dolorum verterem ad ius, his et nullam verterem. Eu alia debet usu, an doming tritani est. Vix ad ponderum petentium suavitate, eum eu tempor populo, graece sententiae constituam vim ex. Cu torquatos reprimique neglegentur nec, voluptua periculis has ut, at eos discere deleniti sensibus. Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea, id minim maiestatis incorrupte duo. Dolorum verterem ad ius, his et nullam verterem. Eu alia debet usu, an doming tritani est. Vix ad ponderum petentium suavitate, eum eu tempor populo, graece sententiae constituam vim ex. Cu torquatos reprimique neglegentur nec, voluptua periculis has ut, at eos discere deleniti sensibus.</div>
-      </div>
-    </iron-collapse>
+<body unresolved class="centered">
 
-    <button class="heading" aria-expanded$="[[isExpanded(opened2)]]" aria-controls="collapse2" onclick="toggle('#collapse2')">Collapse #2</button>
+  <h4>Basic</h4>
+  <demo-snippet>
+    <template>
+      <simple-expand-collapse>
+        <div class="content">
+          Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea, id minim maiestatis incorrupte duo. Dolorum verterem ad ius, his et nullam verterem. Eu alia debet usu, an doming tritani est. Vix ad ponderum petentium suavitate, eum
+          eu tempor populo, graece sententiae constituam vim ex. Cu torquatos reprimique neglegentur nec, voluptua periculis has ut, at eos discere deleniti sensibus. Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea,
+          id minim maiestatis incorrupte duo. Dolorum verterem ad ius, his et nullam verterem. Eu alia debet usu, an doming tritani est. Vix ad ponderum petentium suavitate, eum eu tempor populo, graece sententiae constituam vim ex. Cu torquatos reprimique
+          neglegentur nec, voluptua periculis has ut, at eos discere deleniti sensibus.
+        </div>
+      </simple-expand-collapse>
+    </template>
+  </demo-snippet>
 
-    <iron-collapse id="collapse2" tabindex="0" opened="{{opened2}}">
-      <div class="content">
-        <div>Pro saepe pertinax ei, ad pri animal labores suscipiantur. Modus commodo minimum eum te, vero utinam assueverit per eu, zril oportere suscipiantur pri te. Partem percipitur deterruisset ad sea, at eam suas luptatum dissentiunt. No error alienum pro, erant senserit ex mei, pri semper alterum no. Ut habemus menandri vulputate mea. Feugiat verterem ut sed. Dolores maiestatis id per. Pro saepe pertinax ei, ad pri animal labores suscipiantur. Modus commodo minimum eum te, vero utinam assueverit per eu, zril oportere suscipiantur pri te. Partem percipitur deterruisset ad sea, at eam suas luptatum dissentiunt. No error alienum pro, erant senserit ex mei, pri semper alterum no. Ut habemus menandri vulputate mea. Feugiat verterem ut sed. Dolores maiestatis id per.</div>
+  <h4>Nested, horizontal expand</h4>
+  <demo-snippet>
+    <template>
+      <style>
+        simple-expand-collapse[horizontal] .content {
+          max-height: 250px;
+        }
+      </style>
 
-        <button class="heading" aria-expanded$="[[isExpanded(opened3)]]" aria-controls="collapse3"  onclick="toggle('#collapse3')">Collapse #3 (horizontal)</button>
-
-        <iron-collapse id="collapse3" tabindex="0" opened="{{opened3}}" horizontal>
-          <div class="content">
-            <div>Iisque perfecto dissentiet cum et, sit ut quot mandamus, ut vim tibique splendide instructior. Id nam odio natum malorum, tibique copiosae expetenda mel ea. Mea melius malorum ut. Ut nec tollit vocent timeam. Facer nonumy numquam id his, munere salutatus consequuntur eum et, eum cotidieque definitionem signiferumque id. Ei oblique graecis patrioque vis, et probatus dignissim inciderint vel. Sed id paulo erroribus, autem semper accusamus in mel. Iisque perfecto dissentiet cum et, sit ut quot mandamus, ut vim tibique splendide instructior. Id nam odio natum malorum, tibique copiosae expetenda mel ea. Mea melius malorum ut. Ut nec tollit vocent timeam. Facer nonumy numquam id his, munere salutatus consequuntur eum et, eum cotidieque definitionem signiferumque id. Ei oblique graecis patrioque vis, et probatus dignissim inciderint vel. Sed id paulo erroribus, autem semper accusamus in mel.</div>
+      <simple-expand-collapse>
+        <div class="content">
+          <div>
+            Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea, id minim maiestatis incorrupte duo. Dolorum verterem ad ius, his et nullam verterem. Eu alia debet usu, an doming tritani est. Vix ad ponderum petentium suavitate, eum
+            eu tempor populo, graece sententiae constituam vim ex. Cu torquatos reprimique neglegentur nec, voluptua periculis has ut, at eos discere deleniti sensibus. Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea,
+            id minim maiestatis incorrupte duo. Dolorum verterem ad ius, his et nullam verterem. Eu alia debet usu, an doming tritani est. Vix ad ponderum petentium suavitate, eum eu tempor populo, graece sententiae constituam vim ex. Cu torquatos reprimique
+            neglegentur nec, voluptua periculis has ut, at eos discere deleniti sensibus.
           </div>
-        </iron-collapse>
+          <simple-expand-collapse horizontal>
+            <div class="content">
+              Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea, id minim maiestatis incorrupte duo. Dolorum verterem ad ius, his et nullam verterem. Eu alia debet usu, an doming tritani est. Vix ad ponderum petentium suavitate, eum
+              eu tempor populo, graece sententiae constituam vim ex. Cu torquatos reprimique neglegentur nec, voluptua periculis has ut, at eos discere deleniti sensibus. Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere
+              ea, id minim maiestatis incorrupte duo. Dolorum verterem ad ius, his et nullam verterem. Eu alia debet usu, an doming tritani est. Vix ad ponderum petentium suavitate, eum eu tempor populo, graece sententiae constituam vim ex. Cu torquatos
+              reprimique neglegentur nec, voluptua periculis has ut, at eos discere deleniti sensibus.
+            </div>
+          </simple-expand-collapse>
+        </div>
+      </simple-expand-collapse>
+    </template>
+  </demo-snippet>
 
-        <button class="heading" aria-expanded$="[[isExpanded(opened4)]]" aria-controls="collapse4"  onclick="toggle('#collapse4')">Collapse #4 (no animation)</button>
+  <h4>No animation</h4>
+  <demo-snippet>
+    <template>
+      <simple-expand-collapse no-animation>
+        <div class="content">
+          Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea, id minim maiestatis incorrupte duo. Dolorum verterem ad ius, his et nullam verterem. Eu alia debet usu, an doming tritani est. Vix ad ponderum petentium suavitate, eum
+          eu tempor populo, graece sententiae constituam vim ex. Cu torquatos reprimique neglegentur nec, voluptua periculis has ut, at eos discere deleniti sensibus. Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea,
+          id minim maiestatis incorrupte duo. Dolorum verterem ad ius, his et nullam verterem. Eu alia debet usu, an doming tritani est. Vix ad ponderum petentium suavitate, eum eu tempor populo, graece sententiae constituam vim ex. Cu torquatos reprimique
+          neglegentur nec, voluptua periculis has ut, at eos discere deleniti sensibus.
+        </div>
+      </simple-expand-collapse>
+    </template>
+  </demo-snippet>
+</body>
 
-        <iron-collapse id="collapse4" tabindex="0" opened="{{opened4}}" no-animation>
-          <div class="content">
-            <div>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
-          </div>
-        </iron-collapse>
-      </div>
-    </iron-collapse>
-</template>
-</dom-bind>
-
-<script>
-
-  function toggle(selector) {
-    document.querySelector(selector).toggle();
-  }
-
-  document.querySelector('template[is=dom-bind]').isExpanded = function(opened) {
-    return String(opened);
-  };
-
-</script>
-  </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,7 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
   <link rel="import" href="simple-expand-collapse.html">
 
-  <style is="custom-style" include="demo-pages-shared-styles">
+  <custom-style><style is="custom-style" include="demo-pages-shared-styles">
 
     demo-snippet {
       --demo-snippet-code: {
@@ -39,7 +39,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     .content {
       padding: 15px;
     }
-  </style>
+  </style></custom-style>
 
 </head>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -65,6 +65,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <style>
         simple-expand-collapse[horizontal] .content {
           max-height: 250px;
+          overflow: auto;
         }
       </style>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,7 +20,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="../iron-collapse.html">
     <link rel="import" href="../../paper-styles/shadow.html">
-    <link rel="stylesheet" href="../../paper-styles/demo.css">
 
     <style is="custom-style">
       .heading {
@@ -54,6 +53,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   </head>
   <body unresolved>
+    <dom-bind>
   <template is="dom-bind">
 
     <button class="heading" aria-expanded$="[[isExpanded(opened1)]]" aria-controls="collapse1" onclick="toggle('#collapse1')">Collapse #1</button>
@@ -88,6 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
     </iron-collapse>
 </template>
+</dom-bind>
 
 <script>
 

--- a/demo/simple-expand-collapse.html
+++ b/demo/simple-expand-collapse.html
@@ -42,10 +42,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         border-top: none;
         border-bottom-left-radius: 5px;
         border-bottom-right-radius: 5px;
-        /* TODO(valdrin): Replace with @apply --shadow-elevation-2dp when @apply works. */
-        box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
-                    0 1px 5px 0 rgba(0, 0, 0, 0.12),
-                    0 3px 1px -2px rgba(0, 0, 0, 0.2);
+        @apply --shadow-elevation-2dp;
       }
     </style>
     <button id="trigger" on-click="toggle" aria-expanded$="[[opened]]" aria-controls="collapse">[[_getText(opened)]]</button>

--- a/demo/simple-expand-collapse.html
+++ b/demo/simple-expand-collapse.html
@@ -1,0 +1,89 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../iron-collapse.html">
+<link rel="import" href="../../paper-styles/shadow.html">
+
+<dom-module id="simple-expand-collapse">
+
+  <template>
+
+    <style>
+    
+      :host {
+        display: block;
+      }
+
+      #trigger {
+        padding: 10px 15px;
+        background-color: #f3f3f3;
+        border: 1px solid #dedede;
+        border-radius: 5px;
+        font-size: 18px;
+        cursor: pointer;
+        -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+        text-align: left;
+      }
+
+      :host([opened]) #trigger {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+
+      iron-collapse {
+        border: 1px solid #dedede;
+        border-top: none;
+        border-bottom-left-radius: 5px;
+        border-bottom-right-radius: 5px;
+        /* TODO(valdrin): Replace with @apply --shadow-elevation-2dp when @apply works. */
+        box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
+                    0 1px 5px 0 rgba(0, 0, 0, 0.12),
+                    0 3px 1px -2px rgba(0, 0, 0, 0.2);
+      }
+    </style>
+    <button id="trigger" on-click="toggle" aria-expanded$="[[opened]]" aria-controls="collapse">[[_getText(opened)]]</button>
+    <iron-collapse id="collapse" opened="{{opened}}" horizontal="[[horizontal]]" no-animation="[[noAnimation]]" tabindex="0">
+      <content></content>
+      <slot></slot>
+    </iron-collapse>
+
+  </template>
+
+</dom-module>
+
+<script>
+  Polymer({
+
+    is: 'simple-expand-collapse',
+
+    properties: {
+
+      horizontal: {
+        type: Boolean
+      },
+      opened: {
+        type: Boolean,
+        reflectToAttribute: true
+      },
+      noAnimation: {
+        type: Boolean
+      },
+    },
+
+    toggle: function() {
+      this.$.collapse.toggle();
+    },
+
+    _getText: function(opened) {
+      return opened ? 'Collapse' : 'Expand';
+    }
+
+  });
+</script>

--- a/demo/simple-expand-collapse.html
+++ b/demo/simple-expand-collapse.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template>
 
     <style>
-    
+
       :host {
         display: block;
       }
@@ -50,7 +50,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </style>
     <button id="trigger" on-click="toggle" aria-expanded$="[[opened]]" aria-controls="collapse">[[_getText(opened)]]</button>
     <iron-collapse id="collapse" opened="{{opened}}" horizontal="[[horizontal]]" no-animation="[[noAnimation]]" tabindex="0">
-      <content></content>
       <slot></slot>
     </iron-collapse>
 

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -66,6 +66,8 @@ Custom property | Description | Default
       :host {
         display: block;
         transition-duration: var(--iron-collapse-transition-duration, 300ms);
+        /* Safari 10 needs this property prefixed to correctly apply the custom property */
+        -webkit-transition-duration: var(--iron-collapse-transition-duration, 300ms);
         overflow: visible;
       }
 

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -79,6 +79,7 @@ Custom property | Description | Default
     </style>
 
     <content></content>
+    <slot></slot>
 
   </template>
 
@@ -211,6 +212,11 @@ Custom property | Description | Default
 
       this._desiredSize = size;
 
+      // Set the stored desired size after the element is attached.
+      if (!this.isAttached) {
+        return;
+      }
+
       this._updateTransition(false);
       // If we can animate, must do some prep work.
       if (willAnimate) {
@@ -238,18 +244,6 @@ Custom property | Description | Default
       if (!willAnimate) {
         this._transitionEnd();
       }
-    },
-
-    /**
-     * enableTransition() is deprecated, but left over so it doesn't break existing code.
-     * Please use `noAnimation` property instead.
-     *
-     * @method enableTransition
-     * @deprecated since version 1.0.4
-     */
-    enableTransition: function(enabled) {
-      Polymer.Base._warn('`enableTransition()` is deprecated, use `noAnimation` instead.');
-      this.noAnimation = !enabled;
     },
 
     _updateTransition: function(enabled) {

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -245,6 +245,18 @@ Custom property | Description | Default
         this._transitionEnd();
       }
     },
+    
+    /**
+     * enableTransition() is deprecated, but left over so it doesn't break existing code.
+     * Please use `noAnimation` property instead.
+     *
+     * @method enableTransition
+     * @deprecated since version 1.0.4
+     */
+    enableTransition: function(enabled) {
+      Polymer.Base._warn('`enableTransition()` is deprecated, use `noAnimation` instead.');
+      this.noAnimation = !enabled;
+    },
 
     _updateTransition: function(enabled) {
       this.style.transitionDuration = (enabled && !this.noAnimation) ? '' : '0s';

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -212,11 +212,6 @@ Custom property | Description | Default
 
       this._desiredSize = size;
 
-      // Set the stored desired size after the element is attached.
-      if (!this.isAttached) {
-        return;
-      }
-
       this._updateTransition(false);
       // If we can animate, must do some prep work.
       if (willAnimate) {
@@ -245,7 +240,7 @@ Custom property | Description | Default
         this._transitionEnd();
       }
     },
-    
+
     /**
      * enableTransition() is deprecated, but left over so it doesn't break existing code.
      * Please use `noAnimation` property instead.

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -78,7 +78,6 @@ Custom property | Description | Default
       }
     </style>
 
-    <content></content>
     <slot></slot>
 
   </template>

--- a/test/a11y.html
+++ b/test/a11y.html
@@ -40,6 +40,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var collapse;
 
         setup(function () {
+          // Force focus on body at every test.
+          document.body.focus();
           collapse = fixture('trivialCollapse');
         });
 

--- a/test/a11y.html
+++ b/test/a11y.html
@@ -18,9 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-    <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../iron-collapse.html">
 
   </head>

--- a/test/basic.html
+++ b/test/basic.html
@@ -99,9 +99,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(collapse.transitioning, false, 'transitioning is false');
         });
 
-        test('enableTransition(false) disables animations', function() {
-          collapse.enableTransition(false);
-          assert.isTrue(collapse.noAnimation, '`noAnimation` is true');
+        test('noAnimation disables animations', function() {
+          collapse.noAnimation = true;
           // trying to animate the size update
           collapse.updateSize('0px', true);
           // Animation immediately disabled.

--- a/test/basic.html
+++ b/test/basic.html
@@ -18,11 +18,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-    <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../iron-collapse.html">
-
   </head>
   <body>
 

--- a/test/flex.html
+++ b/test/flex.html
@@ -24,8 +24,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../iron-collapse.html">
 
-    <style is="custom-style" include="iron-flex">
-    </style>
+    <custom-style><style is="custom-style" include="iron-flex">
+    </style></custom-style>
 
   </head>
   <body>

--- a/test/flex.html
+++ b/test/flex.html
@@ -18,17 +18,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
     <link rel="import" href="../../iron-flex-layout/iron-flex-layout-classes.html">
-    <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../iron-collapse.html">
-
-    <custom-style><style is="custom-style" include="iron-flex">
-    </style></custom-style>
-
   </head>
   <body>
+    <custom-style><style is="custom-style" include="iron-flex">
+    </style></custom-style>
 
     <test-fixture id="test">
       <template>

--- a/test/flex.html
+++ b/test/flex.html
@@ -71,9 +71,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('enableTransition(false) disables animations', function() {
-          collapse.enableTransition(false);
-          assert.isTrue(collapse.noAnimation, '`noAnimation` is true');
+        test('noAnimation disables animations', function() {
+          collapse.noAnimation = true;
           // trying to animate the size update
           collapse.updateSize('0px', true);
           // Animation immediately disabled.

--- a/test/flex.html
+++ b/test/flex.html
@@ -21,10 +21,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <link rel="import" href="../../iron-flex-layout/iron-flex-layout-classes.html">
     <link rel="import" href="../iron-collapse.html">
+
+    <custom-style><style is="custom-style" include="iron-flex"></style></custom-style>
   </head>
   <body>
-    <custom-style><style is="custom-style" include="iron-flex">
-    </style></custom-style>
 
     <test-fixture id="test">
       <template>

--- a/test/horizontal.html
+++ b/test/horizontal.html
@@ -17,9 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-    <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../iron-collapse.html">
   </head>
   <body>

--- a/test/index.html
+++ b/test/index.html
@@ -17,16 +17,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
       WCT.loadSuites([
-        'basic.html?wc-shadydom=true&wc-ce=true', //shady
-        'horizontal.html?wc-shadydom=true&wc-ce=true', //shady
-        'a11y.html?wc-shadydom=true&wc-ce=true', //shady
-        'nested.html?wc-shadydom=true&wc-ce=true', //shady
-        'flex.html?wc-shadydom=true&wc-ce=true', //shady
-        'basic.html?dom=shadow', //shadow
-        'horizontal.html?dom=shadow', //shadow
-        'a11y.html?dom=shadow', //shadow
-        'nested.html?dom=shadow', //shadow
-        'flex.html?dom=shadow' //shadow
+        'basic.html?wc-shadydom=true&wc-ce=true',
+        'horizontal.html?wc-shadydom=true&wc-ce=true',
+        'a11y.html?wc-shadydom=true&wc-ce=true',
+        'nested.html?wc-shadydom=true&wc-ce=true',
+        'flex.html?wc-shadydom=true&wc-ce=true',
+        'basic.html?dom=shadow',
+        'horizontal.html?dom=shadow',
+        'a11y.html?dom=shadow',
+        'nested.html?dom=shadow',
+        'flex.html?dom=shadow'
       ]);
     </script>
 

--- a/test/index.html
+++ b/test/index.html
@@ -22,7 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'a11y.html?wc-shadydom=true&wc-ce=true', //shady
         'nested.html?wc-shadydom=true&wc-ce=true', //shady
         'flex.html?wc-shadydom=true&wc-ce=true', //shady
-        'basic.html?dom=shadow&wc-ce=true', //shadow
+        'basic.html?dom=shadow', //shadow
         'horizontal.html?dom=shadow', //shadow
         'a11y.html?dom=shadow', //shadow
         'nested.html?dom=shadow', //shadow

--- a/test/index.html
+++ b/test/index.html
@@ -17,19 +17,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
       WCT.loadSuites([
-        'basic.html',
-        'horizontal.html',
-        'a11y.html',
-        'nested.html',
-        'flex.html',
-        'basic.html?dom=shadow',
-        'horizontal.html?dom=shadow',
-        'a11y.html?dom=shadow',
-        'nested.html?dom=shadow',
-        'flex.html?dom=shadow'
+        'basic.html?wc-shadydom=true&wc-ce=true', //shady
+        'horizontal.html?wc-shadydom=true&wc-ce=true', //shady
+        'a11y.html?wc-shadydom=true&wc-ce=true', //shady
+        'nested.html?wc-shadydom=true&wc-ce=true', //shady
+        'flex.html?wc-shadydom=true&wc-ce=true', //shady
+        'basic.html?dom=shadow&wc-ce=true', //shadow
+        'horizontal.html?dom=shadow', //shadow
+        'a11y.html?dom=shadow', //shadow
+        'nested.html?dom=shadow', //shadow
+        'flex.html?dom=shadow' //shadow
       ]);
     </script>
 
-  
+
 
 </body></html>

--- a/test/nested.html
+++ b/test/nested.html
@@ -17,9 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-    <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../iron-collapse.html">
   </head>
   <body>


### PR DESCRIPTION
- updated `enableTransition` tests to actually test `noAnimation` (`enableTransition` is deprecated since v1.0.4)
- use `demo-snippet` & added new demo element `simple-expand-collapse`