### PR TITLE
check if transitionend was triggered by iron-collapse

### DIFF
--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -206,7 +206,8 @@ Custom property | Description | Default
       // Consider 'auto' as '', to take full size.
       size = size === 'auto' ? '' : size;
 
-      var willAnimate = animated && !this.noAnimation && this.isAttached && this._desiredSize !== size;
+      var willAnimate = animated && !this.noAnimation &&
+                        this.isAttached && this._desiredSize !== size;
 
       this._desiredSize = size;
 

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -120,6 +120,18 @@ Custom property | Description | Default
       },
 
       /**
+       * When true, the element is transitioning its opened state. When false,
+       * the element has finished opening/closing.
+       *
+       * @attribute transitioning
+       */
+      transitioning: {
+        type: Boolean,
+        notify: true,
+        readOnly: true
+      },
+
+      /**
        * Set noAnimation to true to disable animations.
        *
        * @attribute noAnimation
@@ -254,6 +266,7 @@ Custom property | Description | Default
       this.setAttribute('aria-expanded', this.opened);
       this.setAttribute('aria-hidden', !this.opened);
 
+      this._setTransitioning(true);
       this.toggleClass('iron-collapse-closed', false);
       this.toggleClass('iron-collapse-opened', false);
       this.updateSize(this.opened ? 'auto' : '0px', true);
@@ -270,6 +283,7 @@ Custom property | Description | Default
       this.toggleClass('iron-collapse-opened', this.opened);
       this._updateTransition(false);
       this.notifyResize();
+      this._setTransitioning(false);
     },
 
     _onTransitionEnd: function(event) {

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -165,7 +165,7 @@ Custom property | Description | Default
     },
 
     listeners: {
-      transitionend: '_transitionEnd'
+      transitionend: '_onTransitionEnd'
     },
 
     attached: function() {
@@ -278,6 +278,12 @@ Custom property | Description | Default
       this.toggleClass('iron-collapse-opened', this.opened);
       this._updateTransition(false);
       this.notifyResize();
+    },
+
+    _onTransitionEnd: function(event) {
+      if (Polymer.dom(event).rootTarget === this) {
+        this._transitionEnd();
+      }
     },
 
     /**

--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -168,11 +168,6 @@ Custom property | Description | Default
       transitionend: '_onTransitionEnd'
     },
 
-    attached: function() {
-      // It will take care of setting correct classes and styles.
-      this._transitionEnd();
-    },
-
     /**
      * Toggle the opened state.
      *
@@ -198,15 +193,12 @@ Custom property | Description | Default
     updateSize: function(size, animated) {
       // Consider 'auto' as '', to take full size.
       size = size === 'auto' ? '' : size;
-      // No change!
-      if (this._desiredSize === size) {
-        return;
-      }
+
+      var willAnimate = animated && !this.noAnimation && this.isAttached && this._desiredSize !== size;
 
       this._desiredSize = size;
 
       this._updateTransition(false);
-      var willAnimate = animated && !this.noAnimation && this._isDisplayed;
       // If we can animate, must do some prep work.
       if (willAnimate) {
         // Animation will start at the current size.
@@ -284,19 +276,6 @@ Custom property | Description | Default
       if (Polymer.dom(event).rootTarget === this) {
         this._transitionEnd();
       }
-    },
-
-    /**
-     * Simplistic heuristic to detect if element has a parent with display: none
-     *
-     * @private
-     */
-    get _isDisplayed() {
-      var rect = this.getBoundingClientRect();
-      for (var prop in rect) {
-        if (rect[prop] !== 0) return true;
-      }
-      return false;
     },
 
     _calcSize: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -28,7 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <test-fixture id="test">
       <template>
-        <iron-collapse id="collapse" opened>
+        <iron-collapse opened>
           <div style="height:100px;">
             Lorem ipsum
           </div>
@@ -36,10 +36,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
-    <test-fixture id="test-empty">
-    <template>
-        <iron-collapse id="collapse" opened>
-        </iron-collapse>
+    <test-fixture id="empty">
+      <template>
+        <iron-collapse opened></iron-collapse>
       </template>
     </test-fixture>
 
@@ -63,6 +62,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.isTrue(!collapse.noAnimation, '`noAnimation` is falsy');
         });
 
+        test('not transitioning on attached', function() {
+          assert.isTrue(!collapse.transitioning, '`transitioning` is falsy');
+        });
+
         test('horizontal attribute', function() {
           assert.equal(collapse.horizontal, false);
         });
@@ -75,11 +78,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           collapse.opened = false;
           // Animation got enabled.
           assert.notEqual(collapse.style.transitionDuration, '0s');
+          assert.equal(collapse.transitioning, true, 'transitioning became true');
           collapse.addEventListener('transitionend', function() {
             // Animation disabled.
             assert.equal(collapse.style.transitionDuration, '0s');
+            assert.equal(collapse.transitioning, false, 'transitioning became false');
             done();
           });
+        });
+
+        test('transitioning updated only during transitions between open/close states', function() {
+          var spy = sinon.spy();
+          collapse.addEventListener('transitioning-changed', spy);
+          collapse.noAnimation = true;
+          assert.equal(spy.callCount, 0, 'transitioning not affected by noAnimation');
+          collapse.horizontal = true;
+          assert.equal(spy.callCount, 0, 'transitioning not affected by horizontal');
+          collapse.opened = false;
+          assert.equal(spy.callCount, 2, 'transitioning changed twice');
+          assert.equal(collapse.transitioning, false, 'transitioning is false');
         });
 
         test('enableTransition(false) disables animations', function() {
@@ -162,14 +179,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var collapse;
 
         setup(function() {
-          collapse = fixture('test-empty');
+          collapse = fixture('empty');
         });
 
         test('empty&opened shows dynamically loaded content', function(done) {
           flush(function () {
             collapse.toggle();
             collapse.toggle();
-            assert.equal(collapse.style.maxHeight, "");
+            assert.equal(collapse.style.maxHeight, '');
             done();
           });
         });

--- a/test/nested.html
+++ b/test/nested.html
@@ -85,6 +85,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(innerCollapse.getBoundingClientRect().height, 100);
           });
 
+          test('notifyResize triggered only on element\'s animations', function(done) {
+            var spy = sinon.spy(outerCollapse, 'notifyResize');
+
+            outerCollapse.opened = true;
+            innerCollapse.opened = true;
+
+            setTimeout(function() {
+              assert.equal(spy.callCount, 1, 'notifyResize called once');
+              done();
+            }, 400);
+          });
+
         });
 
         suite('horizontal', function() {


### PR DESCRIPTION
Fixes #67 by checking if `transitionend` target is the `iron-collapse` element and by introducing the read-only `transitioning` property which notifies of changes.
The user can listen for these changes to determine if `iron-collapse` is done transitioning from opened to closed (or viceversa).

