### PR TITLE
Address comments from #80

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ collapsable area, not on the area itself. See
 https://www.w3.org/WAI/GL/wiki/Using_aria-expanded_to_indicate_the_state_of_a_collapsible_element#Description
 
 ```html
-<button on-click="toggle">toggle collapse</button>
+<button id="button" on-click="toggle">toggle collapse</button>
 
 <iron-collapse id="collapse">
   <div>Content goes here...</div>

--- a/test/a11y.html
+++ b/test/a11y.html
@@ -51,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // aria-expanded should only be set on the button that
           // controls the collapsable area, not on the area itself.
           // See https://www.w3.org/WAI/GL/wiki/Using_aria-expanded_to_indicate_the_state_of_a_collapsible_element#Description
-          assert.isNotOk(collapse.getAttribute('aria-expanded'));
+          assert.isFalse(collapse.hasAttribute('aria-expanded'));
         });
 
         test('set opened to true', function() {


### PR DESCRIPTION
Add button id on readme example
Check that aria-expanded attribute is not set at all
https://github.com/PolymerElements/iron-collapse/pull/80#pullrequestreview-91985290